### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/argocd/apps/AbstractArgoCD.java
+++ b/src/main/java/io/kestra/plugin/argocd/apps/AbstractArgoCD.java
@@ -43,6 +43,7 @@ public abstract class AbstractArgoCD extends Task {
     )
     @NotNull
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     Property<String> server;
 
     @Schema(
@@ -51,6 +52,7 @@ public abstract class AbstractArgoCD extends Task {
     )
     @NotNull
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     Property<String> token;
 
     @Schema(
@@ -62,10 +64,10 @@ public abstract class AbstractArgoCD extends Task {
 
     @Schema(
         title = "Skip TLS verification",
-        description = "When true (default), adds --insecure to the CLI and skips server certificate validation."
+        description = "When true, adds --insecure to the CLI and skips server certificate validation. Defaults to false (secure). Use the serverCert field to supply a custom CA certificate instead."
     )
     @Builder.Default
-    Property<Boolean> insecure = Property.ofValue(true);
+    Property<Boolean> insecure = Property.ofValue(false);
 
     @Schema(
         title = "Task runner",
@@ -99,6 +101,7 @@ public abstract class AbstractArgoCD extends Task {
         description = "PEM-encoded certificate of the ArgoCD server. Use this when the server uses a self-signed or custom CA certificate. The certificate is written to a temporary file inside the container and passed via `--server-crt`."
     )
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     Property<String> serverCert;
 
     @Schema(
@@ -137,7 +140,6 @@ public abstract class AbstractArgoCD extends Task {
 
     protected String getServerArgs(RunContext runContext) throws IllegalVariableEvaluationException {
         String rServer = runContext.render(this.server).as(String.class).orElseThrow();
-        String rToken = runContext.render(this.token).as(String.class).orElseThrow();
         String rServerCert = runContext.render(this.serverCert).as(String.class).orElse(null);
         Boolean rPlaintext = runContext.render(this.plaintext).as(Boolean.class).orElse(false);
         Boolean rGrpcWeb = runContext.render(this.grpcWeb).as(Boolean.class).orElse(false);
@@ -150,9 +152,11 @@ public abstract class AbstractArgoCD extends Task {
 
         StringBuilder args = new StringBuilder();
         args.append(" --server ").append(rServer);
-        args.append(" --auth-token ").append(rToken);
+        // Pass the auth token via ARGOCD_TOKEN environment variable (set in getEnvironmentVariables)
+        // rather than as a CLI argument, to avoid exposing it in process listings and execution logs.
+        args.append(" --auth-token $ARGOCD_TOKEN");
 
-        boolean rInsecure = runContext.render(this.insecure).as(Boolean.class).orElse(true);
+        boolean rInsecure = runContext.render(this.insecure).as(Boolean.class).orElse(false);
         if (rInsecure) {
             args.append(" --insecure");
         }
@@ -184,6 +188,8 @@ public abstract class AbstractArgoCD extends Task {
             }
         }
 
+        // Pass the auth token via environment variable to avoid exposing it in process listings (CWE-214).
+        runContext.render(this.token).as(String.class).ifPresent(rToken -> envVars.put("ARGOCD_TOKEN", rToken));
         runContext.render(this.serverCert).as(String.class).ifPresent(rServerCert -> envVars.put("ARGOCD_SERVER_CERT", rServerCert));
 
         return envVars;

--- a/src/test/java/io/kestra/plugin/argocd/apps/StatusTest.java
+++ b/src/test/java/io/kestra/plugin/argocd/apps/StatusTest.java
@@ -42,7 +42,7 @@ class StatusTest {
         assertEquals("Warning", output.getConditions().getFirst().get("type"));
         assertEquals("Deployment", output.getResources().getFirst().get("kind"));
         assertEquals(
-            "argocd app get my-application --server argocd.example.com --auth-token token --insecure --output json",
+            "argocd app get my-application --server argocd.example.com --auth-token $ARGOCD_TOKEN --output json",
             task.executedCommands().getFirst()
         );
     }

--- a/src/test/java/io/kestra/plugin/argocd/apps/SyncTest.java
+++ b/src/test/java/io/kestra/plugin/argocd/apps/SyncTest.java
@@ -41,7 +41,7 @@ class SyncTest {
         assertNotNull(output.getResources());
         assertEquals("Deployment", output.getResources().getFirst().get("kind"));
         assertEquals(
-            "argocd app sync my-application --server argocd.example.com --auth-token token --insecure --output json",
+            "argocd app sync my-application --server argocd.example.com --auth-token $ARGOCD_TOKEN --output json",
             task.executedCommands().getFirst()
         );
     }


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Auth token exposed in CLI process arguments (`src/main/java/io/kestra/plugin/argocd/apps/AbstractArgoCD.java:153`)
  - Fix: Removed `--auth-token <plaintext-token>` from the CLI argument string; instead pass the token via the `ARGOCD_TOKEN` environment variable (set in `getEnvironmentVariables()`) and reference it as `--auth-token $ARGOCD_TOKEN` in the command. This follows the same pattern already used for `ARGOCD_SERVER_CERT`.

- **HIGH** TLS certificate verification disabled by default (insecure=true) (`src/main/java/io/kestra/plugin/argocd/apps/AbstractArgoCD.java:68`)
  - Fix: Changed the default value of the `insecure` field from `Property.ofValue(true)` to `Property.ofValue(false)`. Users with self-signed certificates should use the existing `serverCert` field to supply a custom CA certificate.

- **MEDIUM** Secret fields included in Lombok @ToString output (`src/main/java/io/kestra/plugin/argocd/apps/AbstractArgoCD.java:31`)
  - Fix: Added `@ToString.Exclude` to `server`, `token`, and `serverCert` fields so Lombok's generated `toString()` omits these secret values, preventing accidental exposure in logs or exception messages.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-argocd/issues/41
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
