### PR TITLE
Documentation review: plugin-argocd

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.argocd.md
+++ b/src/main/resources/doc/io.kestra.plugin.argocd.md
@@ -6,7 +6,7 @@ Sync and inspect ArgoCD applications from Kestra flows using the ArgoCD CLI.
 
 Set `server` to your ArgoCD API server URL and `token` to a bearer token for ArgoCD CLI authentication. Set `application` to the target ArgoCD application name. Store `token` in a [secret](https://kestra.io/docs/concepts/secret).
 
-By default TLS verification is skipped (`insecure: true`) — set `serverCert` to a PEM-encoded certificate to verify the server instead. For gRPC connections through proxies, set `grpcWeb: true`. The plugin runs the ArgoCD CLI inside a container (`containerImage` defaults to `curlimages/curl:latest`); use `taskRunner` to control where the container runs.
+By default TLS verification is enabled (`insecure: false`); set `insecure: true` to skip certificate validation, or set `serverCert` to a PEM-encoded certificate to verify a self-signed or custom-CA server. For gRPC connections through proxies, set `grpcWeb: true`. The plugin runs the ArgoCD CLI inside a container (`containerImage` defaults to `curlimages/curl:latest`); use `taskRunner` to control where the container runs.
 
 ## Tasks
 


### PR DESCRIPTION
## Documentation review: plugin-argocd

Documentation-only pass over both tasks (`apps.Sync`, `apps.Status`), the `AbstractArgoCD` base,
the how-to doc, and metadata. Task inventory cross-checked against the Kestra plugin registry
(2 tasks, matches). No behavior, validation, or UI-layout changes.

1 file changed.

### Fixed — correctness (security-relevant)
- **The how-to doc stated the wrong `insecure` default.** It said "By default TLS verification is
  skipped (`insecure: true`)", but the code defaults `insecure = false` (secure) and the property's
  `@Schema` says "Defaults to false (secure)". Corrected the doc to state TLS verification is enabled
  by default, with `insecure: true` to skip it or `serverCert` to verify a custom-CA server.

Everything else checked out: both tasks have valid examples using `{{ secret(...) }}`, all outputs
are documented (`syncStatus`/`healthStatus`/`conditions`/`resources`/`rawOutput` plus inherited
`ScriptOutput` fields), and the `apps.yaml`/`index.yaml` metadata and property descriptions are
accurate.
